### PR TITLE
Update publish.yml to use public pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Build and upload Python Package to pypi.autoactuary.com
+name: Build and upload Python Package to pypi
 
 on:
   release:
@@ -22,9 +22,8 @@ jobs:
           pip install setuptools wheel twine
       - name: Build and publish
         env:
-          TWINE_USERNAME: 'aa'
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          TWINE_REPOSITORY_URL: 'https://pypi.autoactuary.com'
         run: |
           python setup.py sdist bdist_wheel
           twine upload dist/*


### PR DESCRIPTION
Do you want the publish.yml workflow in this repo to be similar to release.yml in the python repo? If not, you could accept this PR, which makes the minimal changes needed to change from the Auto Actuary pypi to the public pypi.

All that is needed to make this work is to set the `PYPI_USERNAME` and `PYPI_PASSWORD` secrets in the repo's settings.